### PR TITLE
Allowing File names with spaces

### DIFF
--- a/lib/rtesseract.rb
+++ b/lib/rtesseract.rb
@@ -119,7 +119,7 @@ class RTesseract
     generate_uid
     tmp_file  = Pathname.new(Dir::tmpdir).join("#{@uid}_#{@source.basename}")
     tmp_image = image_to_tiff
-    `#{@command} #{tmp_image} #{tmp_file.to_s} #{lang} #{psm} #{config_file} #{clear_console_output}`
+    `#{@command} '#{tmp_image}' '#{tmp_file.to_s}' #{lang} #{psm} #{config_file} #{clear_console_output}`
     @value = File.read("#{tmp_file.to_s}.txt").to_s
     @uid = nil
     remove_file([tmp_image,"#{tmp_file.to_s}.txt"])


### PR DESCRIPTION
using quotation marks around the generated file names allows for spaces in file names without any RTesseract::ConversionError.
