### PR TITLE
Added ability to read in a string blob

### DIFF
--- a/lib/processors/mini_magick.rb
+++ b/lib/processors/mini_magick.rb
@@ -9,4 +9,14 @@ module MiniMagickProcessor
     cat.write tmp_file.to_s
     return tmp_file
   end
+
+  def image_from_blob
+    generate_uid
+    tmp_file = Pathname.new(Dir::tmpdir).join("#{@uid}_#{@source.basename}.tif").to_s
+    cat = MiniMagick::Image.from_blob(blob)
+    cat.format("tif")
+    cat.crop("#{@w}x#{@h}+#{@x}+#{@y}") unless [@x, @y, @w, @h].compact == []
+    cat.write tmp_file.to_s
+    return tmp_file
+  end
 end

--- a/lib/processors/rmagick.rb
+++ b/lib/processors/rmagick.rb
@@ -8,4 +8,13 @@ module RMagickProcessor
     cat.write tmp_file.to_s
     return tmp_file
   end
+
+  def image_from_blob(blob)
+    generate_uid
+    tmp_file = Pathname.new(Dir::tmpdir).join("#{@uid}_#{@source.basename}.tif").to_s
+    cat = Magick::Image.from_blob(blob).first
+    cat.crop!(@x, @y, @w, @h) unless [@x, @y, @w, @h].compact == []
+    cat.write tmp_file.to_s
+    return tmp_file
+  end
 end

--- a/lib/rtesseract.rb
+++ b/lib/rtesseract.rb
@@ -127,6 +127,19 @@ class RTesseract
     raise RTesseract::ConversionError
   end
 
+  #Read image from memory blob
+  def from_blob(blob)
+    generate_uid
+    tmp_file  = Pathname.new(Dir::tmpdir).join("#{@uid}_#{@source.basename}")
+    tmp_image = image_from_blob(blob)
+    `#{@command} '#{tmp_image}' '#{tmp_file.to_s}' #{lang} #{psm} #{config_file} #{clear_console_output}`
+    @value = File.read("#{tmp_file.to_s}.txt").to_s
+    @uid = nil
+    remove_file([tmp_image,"#{tmp_file.to_s}.txt"])
+  rescue
+    raise RTesseract::ConversionError
+  end
+
   #Output value
   def to_s
     return @value if @value != ""


### PR DESCRIPTION
I've run into a situation where it's required that I create a RMagick image to do some pre-processing of an image (for instance, to increase the density) to allow for better OCR results. In order to avoid having to write a file to disk just to re-read it with RTesseract I thought it would be useful to have the ability to read in a blob created with RMagick's to_blob function.

I have not tested this fully with mini_magick (not what I use), but I stubbed that out anyway to match.

Here's my test case:

blob = Magick::Image.read("some.jpg").first.resample(600).auto_gamma_channel().white_threshold(245).quantize(256,GRAYColorspace).to_blob

test = RTesseract.new("/tmp/bar.tiff") # /tmp/bar.tiff doesn't exist
test.from_blob(blob)
print test.to_s
