### PR TITLE
change apostrophe to double apostrophe because of windows no such file or directory error

### DIFF
--- a/lib/rtesseract.rb
+++ b/lib/rtesseract.rb
@@ -142,7 +142,7 @@ class RTesseract
     generate_uid
     tmp_file  = Pathname.new(Dir::tmpdir).join("#{@uid}_#{@source.basename}")
     tmp_image = image_to_tiff
-    `#{@command} '#{tmp_image}' '#{tmp_file.to_s}' #{lang} #{psm} #{config_file} #{clear_console_output}`
+    `#{@command} "#{tmp_image}" "#{tmp_file.to_s}" #{lang} #{psm} #{config_file} #{clear_console_output}`
     @value = File.read("#{tmp_file.to_s}.txt").to_s
     @uid = nil
     remove_file([tmp_image,"#{tmp_file.to_s}.txt"])
@@ -155,7 +155,7 @@ class RTesseract
     generate_uid
     tmp_file  = Pathname.new(Dir::tmpdir).join("#{@uid}_#{@source.basename}")
     tmp_image = image_from_blob(blob)
-    `#{@command} '#{tmp_image}' '#{tmp_file.to_s}' #{lang} #{psm} #{config_file} #{clear_console_output}`
+    `#{@command} "#{tmp_image}" "#{tmp_file.to_s}" #{lang} #{psm} #{config_file} #{clear_console_output}`
     @value = File.read("#{tmp_file.to_s}.txt").to_s
     @uid = nil
     remove_file([tmp_image,"#{tmp_file.to_s}.txt"])


### PR DESCRIPTION
I managed to run rtessarect on windows (don't ask why, it is long story :D) and I needed to correct one thing. On windows `'` doesn't work correctly causing `No such file or directory` error. To fix this, file names in system commands shuold be written with `"`.

When I cloned repository tests starting with `Path should` were not passing and unfortunately I don't have time to fix this. After the changes no other tests failed.
