### PR TITLE
#9 - updated mini magick processor to convert to tiff without using comp...

### DIFF
--- a/lib/processors/mini_magick.rb
+++ b/lib/processors/mini_magick.rb
@@ -5,7 +5,9 @@ module MiniMagickProcessor
   def image_to_tiff
     tmp_file = Tempfile.new(["",".tif"])
     cat = @instance || read_with_processor(@source.to_s)
-    cat.format("tif")
+    cat.format("tif") do |c|
+      c.compress "None"
+    end
     cat.crop("#{@w}x#{@h}+#{@x}+#{@y}") unless [@x, @y, @w, @h].compact == []
     cat.write tmp_file.path.to_s
     return tmp_file


### PR DESCRIPTION
Similar to the RMagick processor, if you attempt to get the OCR text on a jpg using the MiniMagick processor, you'll get an error about compression not being supported.  Here's an example of the error:

```
MiniMagick::Error:
       Command ("mogrify -format tif /var/folders/_j/xc0nx7fd04l_y3bv8yxg108r0000gn/T/mini_magick20140108-6593-16tc0n7.jpg[0]") failed: {:status_code=>1, :output=>"mogrify: CompressionNotSupported `JPEG' @ error/tiff.c/WriteTIFFImage/2589.\n"}
```

This change disables compression for all formats when converting to tif.
