### PR TITLE
Support command options like 'digits' and 'quiet'

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -78,6 +78,15 @@ Language Options
      * spa   - Spanish
      * vie   - Vietnamese
   Note: Make sure you have installed the language to tesseract
+  
+Other Options
+
+  RTesseract.new("test.jpg", options: :digits)  # Only digit recognition
+  
+  OR
+  
+  RTesseract.new("test.jpg", options: [:digits, :quiet])
+  
 
 == Contributing to rtesseract
  

--- a/lib/rtesseract.rb
+++ b/lib/rtesseract.rb
@@ -16,8 +16,9 @@ class RTesseract
   attr_writer   :lang
   attr_writer   :psm
   attr_reader   :processor
+  attr_accessor :options_cmd
 
-  OPTIONS = %w(command lang psm processor debug clear_console_output)
+  OPTIONS = %w(command lang psm processor debug clear_console_output options)
    # Aliases to languages names
   LANGUAGES = {
     'eng' => %w(en en-us english),
@@ -38,11 +39,13 @@ class RTesseract
   end
 
   def command_line_options(options)
-    @command    = fetch_option(options, :command, default_command)
-    @lang       = fetch_option(options, :lang, '')
-    @psm        = fetch_option(options, :psm, nil)
-    @processor  = fetch_option(options, :processor, 'rmagick')
-    @debug      = fetch_option(options, :debug, false)
+    @command     = fetch_option(options, :command, default_command)
+    @lang        = fetch_option(options, :lang, '')
+    @psm         = fetch_option(options, :psm, nil)
+    @processor   = fetch_option(options, :processor, 'rmagick')
+    @debug       = fetch_option(options, :debug, false)
+    @options_cmd = fetch_option(options, :options, [])
+    @options_cmd = [@options_cmd] unless @options_cmd.kind_of?(Array)
 
     # Disable clear console if debug mode
     @clear_console_output = @debug ? false : fetch_option(options, :clear_console_output, true)
@@ -154,7 +157,7 @@ class RTesseract
 
   # Convert image to string
   def convert
-    `#{@command} "#{image}" "#{text_file.gsub('.txt', '')}" #{lang} #{psm} #{config_file} #{clear_console_output}`
+    `#{@command} "#{image}" "#{text_file.gsub('.txt', '')}" #{lang} #{psm} #{config_file} #{clear_console_output} #{@options_cmd.join(' ')}`
     @value = File.read(@text_file).to_s
     remove_file([@image, @text_file])
   rescue => error

--- a/spec/rtesseract_spec.rb
+++ b/spec/rtesseract_spec.rb
@@ -74,6 +74,13 @@ describe "Rtesseract" do
     RTesseract.new(@image_tiff,{:lang=>MakeStringError.new}).lang.should eql("")
   end
 
+  it " select options" do
+     expect(RTesseract.new(@image_tiff).options_cmd).to eql([])
+     expect(RTesseract.new(@image_tiff, options: 'digits').options_cmd).to eql(['digits'])
+     expect(RTesseract.new(@image_tiff, options: :digits).options_cmd).to eql([:digits])
+     expect(RTesseract.new(@image_tiff, options: [:digits, :quiet]).options_cmd).to eql([:digits, :quiet])
+  end
+  
   it " be configurable" do
      RTesseract.new(@image_tiff,{:chop_enable=>0,:enable_assoc=>0,:display_text=>0}).config.should eql("chop_enable 0\nenable_assoc 0\ndisplay_text 0")
      RTesseract.new(@image_tiff,{:chop_enable=>0}).config.should eql("chop_enable 0")


### PR DESCRIPTION
Add tesseract options from command line like 'digits' and 'quiet'.

Only tested with tesseract 3.02
