### PR TITLE
Add source getter method for RTesseract

### DIFF
--- a/lib/rtesseract.rb
+++ b/lib/rtesseract.rb
@@ -18,10 +18,11 @@ require 'processors/none.rb'
 class RTesseract
   attr_accessor :image_object
   attr_accessor :options
+  attr_accessor :options_cmd
   attr_writer :lang
   attr_writer :psm
   attr_reader :processor
-  attr_accessor :options_cmd
+  attr_reader :source
 
   OPTIONS = %w(command lang psm processor debug clear_console_output options)
   # Aliases to languages names

--- a/spec/rtesseract_spec.rb
+++ b/spec/rtesseract_spec.rb
@@ -59,6 +59,11 @@ describe 'Rtesseract' do
     expect(image.to_s_without_spaces).to eql('V2V4')
   end
 
+  it ' returns the source' do
+    image = RTesseract.new(@image_tif)
+    expect(image.source).to eql(Pathname.new(@image_tif))
+  end
+
   it ' select the language' do
     # English
     expect(RTesseract.new(@image_tif, lang: 'eng').lang).to eql(' -l eng ')


### PR DESCRIPTION
The current Readme states that we can do the following:

```
image = RTesseract.new("my_image.jpg")
image.source = "new_image.png"
```

However, upon inspection, the `source` method does not exist.