### PR TITLE
Add default processor configure support

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -70,6 +70,14 @@ Processors Options  (_Rmagick_ is default)
 
   RTesseract.new("test.jpg", :processor => "none")
 
+Or you can config default processor first:
+
+  RTesseract.configure do |config|
+    config.processor = "mini_magick"
+  end
+
+  RTesseract.new("test.jpg") # It will use mini_magick by default
+
 Language Options
 
   RTesseract.new("test.jpg", :lang => "deu")

--- a/lib/rtesseract.rb
+++ b/lib/rtesseract.rb
@@ -33,6 +33,27 @@ class RTesseract
     'spa' => %w(sp)
   }
 
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configure
+    self.configuration ||= Configuration.new
+    yield(configuration)
+  end
+
+  class Configuration
+    attr_accessor :processor
+
+    def initialize
+      @processor = 'rmagick'
+    end
+
+    def to_hash
+      {processor: @processor}
+    end
+  end
+
   def initialize(src = '', options = {})
     command_line_options(options)
     @value, @x, @y, @w, @h = [nil]
@@ -45,7 +66,8 @@ class RTesseract
   end
 
   def command_line_options(options)
-    @options = options
+    default_config = RTesseract.configuration ? RTesseract.configuration.to_hash : {}
+    @options = default_config.merge(options)
     @command = @options.option(:command, default_command)
     @lang = @options.option(:lang, '')
     @psm = @options.option(:psm, nil)

--- a/spec/rtesseract_spec.rb
+++ b/spec/rtesseract_spec.rb
@@ -38,7 +38,7 @@ describe 'Rtesseract' do
     #expect(RTesseract.new(@path.join('images', 'README.pdf').to_s, debug: true).to_s_without_spaces).to eql('')
   end
 
-  it ' support  diferent processors' do
+  it ' support  different processors' do
     # Rmagick
     expect(RTesseract.new(@image_tif).to_s_without_spaces).to eql('43XF')
     expect(RTesseract.new(@image_tif, processor: 'rmagick').to_s_without_spaces).to eql('43XF')
@@ -55,6 +55,7 @@ describe 'Rtesseract' do
     # NoneMagick
     expect(RTesseract.new(@image_tif, processor: 'none').to_s_without_spaces).to eql('43XF')
   end
+
 
   it ' change the image' do
     image = RTesseract.new(@image_tif)
@@ -184,4 +185,23 @@ describe 'Rtesseract' do
 
     expect { rtesseract.remove_file(Pathname.new(Dir.tmpdir).join('test_not_exists')) }.to raise_error(RTesseract::TempFilesNotRemovedError)
   end
+
+  it ' support  default config processors' do
+    # Rmagick
+    RTesseract.configure {|config| config.processor = 'rmagick' }
+    expect(RTesseract.new(@image_tif).processor.a_name?('rmagick')).to eql(true)
+
+    # MiniMagick
+    RTesseract.configure {|config| config.processor = 'mini_magick' }
+    expect(RTesseract.new(@image_tif).processor.a_name?('mini_magick')).to eql(true)
+
+    # QuickMagick
+    RTesseract.configure {|config| config.processor = 'quick_magick' }
+    expect(RTesseract.new(@image_tif).processor.a_name?('quick_magick')).to eql(true)
+
+    # NoneMagick
+    RTesseract.configure {|config| config.processor = 'none' }
+    expect(RTesseract.new(@image_tif).processor.a_name?('none')).to eql(true)
+  end
+
 end


### PR DESCRIPTION
Many projects only need one of `mini_magick` or `rmagick`, To initialize a `RTesseract` object with `processor` option every time, it is not beautiful, so I add this: 

```
   RTesseract.configure do |config|
     config.processor = "mini_magick"
   end

   RTesseract.new("test.jpg") # It will use mini_magick by default
```