### PR TITLE
Improve PDF support

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -15,6 +15,7 @@ To work properly rtesseract are needed:
 * RMagick or mini_magick - Gem
 
 Atention: Version 1.0.0 works fine with Ruby 2.0 and tesseract 3.0 and lower versions of rtesseract works fine with Ruby 1.8 and tesseract 2.0.4.
+
 PDF support requires a newer version of tesseract, specifically V.3.03 or above.
 
 == EXAMPLE USAGE
@@ -26,15 +27,17 @@ It's very simple to use rtesseract:
   image = RTesseract.new("my_image.jpg")
   image.to_s #Getting the value
 
-=== CONVERT IMAGE TO SEARCHABLE PDF (needs tesseract versions >=3.03)
+=== CONVERT IMAGE TO SEARCHABLE PDF
 
-  image = RTesseract.new("my_image.jpg", options: 'pdf')
-  image.to_pdf # Getting the pdf path
-  # ... some stuff
-  image.clean # to delete file once finished.
+  image = RTesseract.new("my_image.jpg")
+  image.to_pdf  # Getting the pdf path
+  image.to_s    # to get the text only
+  # ...
+  # some stuff
+  # ...
+  image.clean   # to delete file once finished
 
-This will preserve the document colors, pictures and structure.
-Pleas note that (#to_s) does not work with a RTesseract instance configured with option: 'pdf'. You need another instantiation without 'pdf' option to get the raw text by #to_s.
+This will preserve the image colors, pictures and structure in the generated pdf.
 
 === CHANGE THE IMAGE
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -25,13 +25,13 @@ It's very simple to use rtesseract:
 === CONVERT IMAGE TO STRING
 
   image = RTesseract.new("my_image.jpg")
-  image.to_s #Getting the value
+  image.to_s # Getting the value
 
 === CONVERT IMAGE TO SEARCHABLE PDF
 
   image = RTesseract.new("my_image.jpg")
   image.to_pdf  # Getting the pdf path
-  image.to_s    # to get the text only
+  image.to_s    # Still can get the value only.
   # ...
   # some stuff
   # ...

--- a/lib/rtesseract.rb
+++ b/lib/rtesseract.rb
@@ -195,6 +195,9 @@ class RTesseract
   def to_pdf
     return @pdf_path if @pdf_path != nil && pdf?
 
+    tess_version = RTesseract::Utils.version_number
+    fail TesseractVersionError.new if tess_version && tess_version < 3.03
+
     if @processor.image?(@source) || @source.file?
       convert
     else

--- a/lib/rtesseract.rb
+++ b/lib/rtesseract.rb
@@ -28,6 +28,7 @@ class RTesseract
   # Define the source
   def source=(src)
     @value = nil
+    @pdf_path = nil
     @source = @processor.image?(src) ? src : Pathname.new(src)
   end
 
@@ -126,6 +127,12 @@ class RTesseract
     '.txt'
   end
 
+  # Detect version number
+  def tesseract_version
+    RTesseract::Utils.version_number
+  end
+
+
   # Rand file path
   def file_dest
     @file_dest = Pathname.new(Dir.tmpdir).join("#{Time.now.to_f}#{rand(1500)}").to_s
@@ -136,14 +143,14 @@ class RTesseract
     [@file_dest, ext || file_ext].join('')
   end
 
-  # Is pdf output?
-  def pdf?
-    options_cmd.map(&:to_sym).include? :pdf
-  end
-
   # Run command
   def convert_command
-    `#{configuration.command} "#{image}" "#{file_dest}" #{lang} #{psm} #{tessdata_dir} #{user_words} #{user_patterns} #{config_file} #{clear_console_output} #{configuration.options_cmd.join(' ')}`
+    `#{configuration.command} "#{image}" "#{file_dest}" #{lang} #{psm} #{tessdata_dir} #{user_words} #{user_patterns} #{config_file} #{clear_console_output} #{options_cmd.join(' ')}`
+  end
+
+  # Is pdf output?
+  def pdf?
+    options_cmd.include? 'pdf'
   end
 
   # Read result file
@@ -152,8 +159,18 @@ class RTesseract
   end
 
   # Store pdf result path
-  def obtain_pdf
+  def convert_pdf
     @pdf_path = file_with_ext('.pdf')
+  end
+
+  # Convert result to proper type
+  def convert_result
+    if pdf?
+      convert_pdf
+    else
+      convert_text
+      RTesseract::Utils.remove_files([@image, file_with_ext])
+    end
   end
 
   # Hook to convert
@@ -164,19 +181,14 @@ class RTesseract
   def convert
     convert_command
     after_convert_hook
-    if pdf?
-      obtain_pdf
-    else
-      convert_text
-      RTesseract::Utils.remove_files([@image, file_with_ext])
-    end
+    convert_result
   rescue => error
     raise RTesseract::ConversionError.new(error), error, caller
   end
 
   # Output value
   def to_s
-    return @value if @value != nil || pdf?
+    return @value if @value
 
     if @processor.image?(@source) || @source.file?
       convert
@@ -193,13 +205,15 @@ class RTesseract
 
   # Output pdf path
   def to_pdf
-    return @pdf_path if @pdf_path != nil && pdf?
+    return @pdf_path if @pdf_path
 
-    tess_version = RTesseract::Utils.version_number
-    fail TesseractVersionError.new if tess_version && tess_version < 3.03
+    fail TesseractVersionError.new if tesseract_version && tesseract_version < 3.03
 
     if @processor.image?(@source) || @source.file?
+      options_cmd << 'pdf'
       convert
+      options_cmd.delete('pdf')
+      @pdf_path
     else
       fail RTesseract::ImageNotSelectedError.new(@source)
     end

--- a/lib/rtesseract.rb
+++ b/lib/rtesseract.rb
@@ -207,7 +207,7 @@ class RTesseract
   def to_pdf
     return @pdf_path if @pdf_path
 
-    fail TesseractVersionError.new if tesseract_version && tesseract_version < 3.03
+    fail TesseractVersionError.new if tesseract_version.nil? || tesseract_version < 3.03
 
     if @processor.image?(@source) || @source.file?
       options_cmd << 'pdf'

--- a/lib/rtesseract/configuration.rb
+++ b/lib/rtesseract/configuration.rb
@@ -43,6 +43,15 @@ class RTesseract
   def self.configure
     self.configuration ||= Configuration.new
     yield(configuration)
+    self.clear_pdf_option
+  end
+
+  # Clear pdf option
+  def self.clear_pdf_option
+    if self.configuration.options_cmd
+      self.configuration.options_cmd.delete('pdf')
+      self.configuration.options_cmd.delete(:pdf)
+    end
   end
 
   # Default command
@@ -59,7 +68,8 @@ class RTesseract
       config.processor = config.option(options, :processor, 'rmagick')
       config.load_options(options, [:lang, :psm, :tessdata_dir, :user_words, :user_patterns])
       config.debug = config.option(options, :debug, false)
-      config.options_cmd = [options.option(:options, nil)].flatten.compact
+      pdf_opts = -> (o) { o == 'pdf' || o == :pdf }
+      config.options_cmd = [options.option(:options, nil)].delete_if(&pdf_opts).flatten.compact
     end
   end
 end

--- a/lib/rtesseract/configuration.rb
+++ b/lib/rtesseract/configuration.rb
@@ -68,7 +68,7 @@ class RTesseract
       config.processor = config.option(options, :processor, 'rmagick')
       config.load_options(options, [:lang, :psm, :tessdata_dir, :user_words, :user_patterns])
       config.debug = config.option(options, :debug, false)
-      pdf_opts = -> (o) { o == 'pdf' || o == :pdf }
+      pdf_opts = lambda { |o| o == 'pdf' || o == :pdf }
       config.options_cmd = [options.option(:options, nil)].delete_if(&pdf_opts).flatten.compact
     end
   end

--- a/lib/rtesseract/errors.rb
+++ b/lib/rtesseract/errors.rb
@@ -12,4 +12,10 @@ class RTesseract
   class ConversionError < ErrorWithMemory; end
   class ImageNotSelectedError < ErrorWithMemory; end
   class TempFilesNotRemovedError < ErrorWithMemory; end
+  
+  class TesseractVersionError < StandardError 
+    def initialize 
+      super "Tesseract version is unknown or below 3.03 which is required for pdf output."
+    end
+  end
 end

--- a/lib/rtesseract/utils.rb
+++ b/lib/rtesseract/utils.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 # RTesseract
 class RTesseract
   # Some utils methods
@@ -21,6 +23,14 @@ class RTesseract
         File.unlink(file)
       end
       true
+    end
+
+    # Extract tesseract version number
+    def self.version_number
+      out, err, st = Open3.capture3(RTesseract.default_command, "--version")
+      
+      version = err.split("\n")[0].split(" ")[1].split('.')[0, 2].join('.')
+      Float(version) rescue nil
     end
   end
 end

--- a/spec/rtesseract_spec.rb
+++ b/spec/rtesseract_spec.rb
@@ -116,6 +116,16 @@ describe 'Rtesseract' do
     expect(File.exists?(pdf_ocr.to_pdf)).to eql(false)
   end
 
+  it ' warn when tesseract cannot give pdf' do
+    rtesseract = RTesseract.new(@image_for_pdf)
+
+    allow(rtesseract).to receive(:tesseract_version).and_return(3.02)
+    expect { rtesseract.to_pdf }.to raise_error(RTesseract::TesseractVersionError)
+
+    allow(rtesseract).to receive(:tesseract_version).and_return(3.03)
+    expect { rtesseract.to_pdf }.not_to raise_error
+  end
+
   it ' be configurable' do
     expect(RTesseract.new(@image_tif, chop_enable: 0, enable_assoc: 0, display_text: 0).config).to eql("chop_enable 0\nenable_assoc 0\ndisplay_text 0")
     expect(RTesseract.new(@image_tif, chop_enable: 0).config).to eql('chop_enable 0')

--- a/spec/rtesseract_spec.rb
+++ b/spec/rtesseract_spec.rb
@@ -195,6 +195,10 @@ describe 'Rtesseract' do
     expect { RTesseract::Utils.remove_files(Pathname.new(Dir.tmpdir).join('test_not_exists')) }.to raise_error(RTesseract::TempFilesNotRemovedError)
   end
 
+  it ' get a numeric value for tesseract version' do
+    expect(RTesseract::Utils.version_number).to be_a Float
+  end
+
   it ' support  default config processors' do
     # Rmagick
     RTesseract.configure { |config| config.processor = 'rmagick' }


### PR DESCRIPTION
Hi @dannnylo,

By now, hopefully RTesseract supports both `#to_pdf` and `#to_s` without conflict and full compatibility at the same time 😌.
 
I had to treat `options: :pdf` in a different way than the other `options_cmd`, because unlike the others, it alters Tesseract outputted file and we don't want that while in `#to_s` (previously we exit if `:pdf` is specified).

So, please let me know about any notices, whether this is the way to go, or if something's missing.
Kindly 🎩.