### PR TITLE
Add Uzn class.

### DIFF
--- a/lib/rtesseract.rb
+++ b/lib/rtesseract.rb
@@ -227,6 +227,7 @@ class RTesseract
 end
 
 require 'rtesseract/mixed'
+require 'rtesseract/uzn'
 require 'rtesseract/box'
 require 'rtesseract/box_char'
 require 'rtesseract/blob'

--- a/lib/rtesseract/uzn.rb
+++ b/lib/rtesseract/uzn.rb
@@ -1,0 +1,47 @@
+# encoding: UTF-8
+# RTesseract
+class RTesseract
+  # Alternative approach to Mixed when you want to read from specific areas.
+  # Requires `-psm 4` which means the text must be "a single column of text of variable sizes".
+  class Uzn < RTesseract
+    attr_reader :areas
+    DEFAULT_ALPHABET = 'Text/Latin'
+
+    def initialize(src = '', options = {})
+      @areas = options.delete(:areas) || []
+      @alphabet = options.delete(:alphabet) || DEFAULT_ALPHABET
+      super(src, options.merge(psm: 4))
+      yield self if block_given?
+    end
+
+    # Add areas
+    def area(points)
+      areas << points
+    end
+
+    def convert_command
+      @image = image
+      write_uzn_file
+      `#{configuration.command} "#{@image}" "#{file_dest}" #{lang} #{psm} #{tessdata_dir} #{user_words} #{user_patterns} #{config_file} #{clear_console_output} #{options_cmd.join(' ')}`
+    end
+
+    def after_convert_hook
+      RTesseract::Utils.remove_files([@uzn_file])
+    end
+
+    private
+
+    def write_uzn_file
+      folder = File.dirname(@image)
+      basename = File.basename(@image, '.tif')
+      @uzn_file = File.new("#{folder}/#{basename}.uzn", File::CREAT|File::TRUNC|File::RDWR)
+
+      areas.each do |points|
+        s = "#{points[:x]} #{points[:y]} #{points[:w]} #{points[:h]} #{@alphabet}\n"
+        @uzn_file.write(s)
+        @uzn_file.flush
+      end
+    end
+
+  end
+end

--- a/spec/rtesseract_uzn_spec.rb
+++ b/spec/rtesseract_uzn_spec.rb
@@ -1,0 +1,56 @@
+# encoding: UTF-8
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+
+describe 'Rtesseract::Uzn' do
+  before do
+    @path = Pathname.new(__FILE__.gsub('rtesseract_uzn_spec.rb', '')).expand_path
+    @image_tif = @path.join('images', 'mixed.tif').to_s
+  end
+
+  it 'should be instantiable' do
+    expect(RTesseract::Uzn.new.class).to eql(RTesseract::Uzn)
+    expect(RTesseract::Uzn.new(@image_tif).class).to eql(RTesseract::Uzn)
+  end
+
+  it 'should translate parts of the image to text from a block' do
+    uzn_block = RTesseract::Uzn.new(@image_tif) do |image|
+      image.area(x: 28, y: 19, w: 25, h: 25) # position of 4
+      image.area(x: 180, y: 22, w: 20, h: 28) # position of 3
+      image.area(x: 218, y: 22, w: 24, h: 28) # position of F
+      image.area(x: 248, y: 24, w: 22, h: 22) # position of F
+    end
+
+    expect(uzn_block.to_s_without_spaces).to eql('43FF')
+  end
+
+  it 'should translate parts of the image to text from initializer options' do
+    @areas = []
+    @areas << { x: 28, y: 19, w: 25, h: 25 } # position of 4
+    @areas << { x: 180, y: 22, w: 20, h: 28 } # position of 3
+    @areas << { x: 218, y: 22, w: 24, h: 28 } # position of f
+    @areas << { x: 248, y: 24, w: 22, h: 22 }  # position of f
+
+    uzn_block = RTesseract::Uzn.new(@image_tif, areas: @areas)
+    expect(uzn_block.to_s_without_spaces).to eql('43FF')
+  end
+
+  it 'should handle a blank image' do
+    @areas = []
+    @areas << { x: 28, y: 19, w: 25, h: 25 } # position of 4
+    @areas << { x: 180, y: 22, w: 20, h: 28 } # position of 3
+    @areas << { x: 218, y: 22, w: 24, h: 28 } # position of f
+    @areas << { x: 248, y: 24, w: 22, h: 22 }  # position of f
+    uzn_block = RTesseract::Uzn.new(@path.join('images', 'blank.tif').to_s, areas: @areas)
+    expect(uzn_block.to_s_without_spaces).to eql('')
+  end
+
+  it ' get a error' do
+    @areas = [{ x: 28, y: 19, w: 25, h: 25 }]
+
+    uzn_block = RTesseract::Uzn.new(@path.join('images', 'test_not_exists.png').to_s, areas: @areas, psm: 7)
+    expect { uzn_block.to_s_without_spaces }.to raise_error(RTesseract::ImageNotSelectedError)
+
+    uzn_block = RTesseract::Uzn.new(@image_tif, areas: @areas, psm: 7, command: 'tesseract_error')
+    expect { uzn_block.to_s }.to raise_error(RTesseract::ConversionError)
+  end
+end


### PR DESCRIPTION
Use tesseract UZN file to extract text from portions of image. [See here](https://github.com/OpenGreekAndLatin/greek-dev/wiki/uzn-format) for more details on UZN format.

`RTesseract::Uzn` provides basically the same functionality as `RTesseract::Mixed` but with faster processing at the cost of some limitations (namely, the requirement of `-psm 4`). In my experience, recognition results are sometimes better with the `Uzn` vs `Mixed`.

Uzn specs basically copy the Mixed specs, but split some into separate tests.

The `initialize` logic for Uzn must remove `areas` before calling `super` so that they don't get passed into the `options_cmd` for the config file.

Benchmarking:

```ruby
require 'benchmark'

path = Pathname.new(Dir.pwd).join('spec', 'images', 'mixed.tif')
mix_block = RTesseract::Mixed.new(path.to_s, psm: 7) do |image|
  image.area(x: 28, y: 19, w: 25, h: 25) # position of 4
  image.area(x: 180, y: 22, w: 20, h: 28) # position of 3
  image.area(x: 218, y: 22, w: 24, h: 28) # position of F
  image.area(x: 248, y: 24, w: 22, h: 22) # position of F
end

uzn_block = RTesseract::Uzn.new(path.to_s) do |image|
  image.area(x: 28, y: 19, w: 25, h: 25) # position of 4
  image.area(x: 180, y: 22, w: 20, h: 28) # position of 3
  image.area(x: 218, y: 22, w: 24, h: 28) # position of F
  image.area(x: 248, y: 24, w: 22, h: 22) # position of F
end

Benchmark.bmbm do |b|
  b.report('mix_block') { mix_block.to_s }
  b.report('uzn_block') { uzn_block.to_s }
end

Rehearsal ---------------------------------------------
mix_block   0.010000   0.010000   0.770000 (  0.785186)
uzn_block   0.000000   0.010000   0.220000 (  0.211077)
------------------------------------ total: 0.990000sec

                user     system      total        real
mix_block   0.000000   0.000000   0.000000 (  0.000010)
uzn_block   0.000000   0.000000   0.000000 (  0.000004)
```