### PR TITLE
Add special handling for errors resulting from tesseract shell command.

### DIFF
--- a/lib/rtesseract.rb
+++ b/lib/rtesseract.rb
@@ -180,10 +180,15 @@ class RTesseract
   # Convert image to string
   def convert
     convert_command
-    after_convert_hook
-    convert_result
-  rescue => error
-    raise RTesseract::ConversionError.new(error), error, caller
+    if $? && !$?.success?
+      failed_command!
+    end
+    begin
+      after_convert_hook
+      convert_result
+    rescue => error
+      raise RTesseract::ConversionError.new(error), error, caller
+    end
   end
 
   # Output value
@@ -222,6 +227,16 @@ class RTesseract
   # Destroy pdf file
   def clean
     RTesseract::Utils.remove_files([@pdf_path])
+  end
+
+  private
+
+  def failed_command!
+    if $?.exitstatus == 127
+      raise TesseractNotInstalledError
+    else
+      raise TesseractCommandError, $?.to_s
+    end
   end
 
 end

--- a/lib/rtesseract/errors.rb
+++ b/lib/rtesseract/errors.rb
@@ -12,6 +12,8 @@ class RTesseract
   class ConversionError < ErrorWithMemory; end
   class ImageNotSelectedError < ErrorWithMemory; end
   class TempFilesNotRemovedError < ErrorWithMemory; end
+  class TesseractCommandError < StandardError; end
+  class TesseractNotInstalledError < TesseractCommandError; end
   
   class TesseractVersionError < StandardError 
     def initialize 

--- a/lib/rtesseract/mixed.rb
+++ b/lib/rtesseract/mixed.rb
@@ -31,6 +31,8 @@ class RTesseract
         image.crop!(area)
         @value << image.to_s
       end
+    rescue RTesseract::TesseractCommandError
+      raise
     rescue => error
       raise RTesseract::ConversionError.new(error), error, caller
     end

--- a/spec/rtesseract_box_char_spec.rb
+++ b/spec/rtesseract_box_char_spec.rb
@@ -75,7 +75,7 @@ describe 'Rtesseract::BoxChar' do
 
     expect(RTesseract::BoxChar.new(@words_image).characters).to eql(@values)
 
-    expect { RTesseract::BoxChar.new(@image_tiff, command: 'tesseract_error').to_s }.to raise_error(RTesseract::ConversionError)
+    expect { RTesseract::BoxChar.new(@image_tiff, command: 'tesseract_error').to_s }.to raise_error(RTesseract::TesseractNotInstalledError)
     expect { RTesseract::BoxChar.new(@image_tiff + '_not_exist').to_s }.to raise_error(RTesseract::ImageNotSelectedError)
     # expect(RTesseract::BoxChar.new(@path.join('images', 'blank.tif').to_s, options: :digits).characters).to eql([])
   end

--- a/spec/rtesseract_box_spec.rb
+++ b/spec/rtesseract_box_spec.rb
@@ -29,7 +29,7 @@ describe 'Rtesseract::Box' do
 
     expect(RTesseract::Box.new(@image_tiff).words.is_a?(Array)).to eql(true)
     expect(RTesseract::Box.new(@words_image).to_s).to eql('If you are a friend, you speak the password, and the doors will open.')
-    expect { RTesseract::Box.new(@image_tiff, command: 'tesseract_error').to_s }.to raise_error(RTesseract::ConversionError)
+    expect { RTesseract::Box.new(@image_tiff, command: 'tesseract_error').to_s }.to raise_error(RTesseract::TesseractNotInstalledError)
     expect { RTesseract::Box.new(@image_tiff + '_not_exist').to_s }.to raise_error(RTesseract::ImageNotSelectedError)
     # expect(RTesseract::Box.new(@path.join('images', 'blank.tif').to_s, options: :digits).words).to eql([])
   end

--- a/spec/rtesseract_mixed_spec.rb
+++ b/spec/rtesseract_mixed_spec.rb
@@ -44,6 +44,6 @@ describe 'Rtesseract::Mixed' do
     expect { mix_block.to_s_without_spaces }.to raise_error(RTesseract::ImageNotSelectedError)
 
     mix_block = RTesseract::Mixed.new(@image_tif, areas: @areas, psm: 7, command: 'tesseract_error')
-    expect { mix_block.to_s }.to raise_error(RTesseract::ConversionError)
+    expect { mix_block.to_s }.to raise_error(RTesseract::TesseractNotInstalledError)
   end
 end

--- a/spec/rtesseract_spec.rb
+++ b/spec/rtesseract_spec.rb
@@ -205,11 +205,14 @@ describe 'Rtesseract' do
   end
 
   it ' get a error' do
-    expect { RTesseract.new(@path.join('images', 'test.jpg').to_s, command: 'tesseract_error').to_s }.to raise_error(RTesseract::ConversionError)
     expect { RTesseract.new(@path.join('images', 'test_not_exists.png').to_s).to_s }.to raise_error(RTesseract::ImageNotSelectedError)
 
     # Invalid psm object
     expect(RTesseract.new(@image_tif, psm:  MakeStringError.new).psm).to eql('')
+  end
+
+  it 'tesseract not installed' do
+    expect { RTesseract.new(@path.join('images', 'test.jpg').to_s, command: 'tesseract_error').to_s }.to raise_error(RTesseract::TesseractNotInstalledError)
   end
 
   it 'remove a file' do

--- a/spec/rtesseract_uzn_spec.rb
+++ b/spec/rtesseract_uzn_spec.rb
@@ -51,6 +51,6 @@ describe 'Rtesseract::Uzn' do
     expect { uzn_block.to_s_without_spaces }.to raise_error(RTesseract::ImageNotSelectedError)
 
     uzn_block = RTesseract::Uzn.new(@image_tif, areas: @areas, psm: 7, command: 'tesseract_error')
-    expect { uzn_block.to_s }.to raise_error(RTesseract::ConversionError)
+    expect { uzn_block.to_s }.to raise_error(RTesseract::TesseractNotInstalledError)
   end
 end


### PR DESCRIPTION
If the tesseract shell command fails (tesseract is not installed, command-line options are malformed, etc.) then we can raise a slightly more informative error.

We do some extra checking (e.g. for non-nil $?) to hopefully be compatible with non-POSIX systems like Windows, which may not behave the same way w.r.t ruby's Process::Status.

Some sources state that POSIX shells in general should use code 127 in this case, though I was not able to find a canonical source and Wikipedia indicates this may not be true for all shells.