### PR TITLE
Missing dash - for psm option

### DIFF
--- a/lib/rtesseract.rb
+++ b/lib/rtesseract.rb
@@ -67,7 +67,7 @@ class RTesseract
 
   # Page Segment Mode
   def psm
-    option_to_string('-psm', configuration.psm)
+    option_to_string('--psm', configuration.psm)
   end
 
   # Engine Mode

--- a/spec/rtesseract_spec.rb
+++ b/spec/rtesseract_spec.rb
@@ -244,7 +244,7 @@ describe 'Rtesseract' do
     expect(RTesseract.new(@image_tif).lang).to eql(' -l por ')
 
     RTesseract.configure { |config| config.psm = 7 }
-    expect(RTesseract.new(@image_tif).psm).to eql(' -psm 7 ')
+    expect(RTesseract.new(@image_tif).psm).to eql(' --psm 7 ')
 
     RTesseract.configure { |config| config.tessdata_dir = '/tmp/test' }
     expect(RTesseract.new(@image_tif).tessdata_dir).to eql(' --tessdata-dir /tmp/test ')


### PR DESCRIPTION
Oops, I just realized that this fix only applies to tesseract 3.05+, not 3.04. I'm not sure how the library could detect which version of tesseract is installed, maybe we could pass the version as an option.