### PR TITLE
Force command method on config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v3.0.3
+
+#### Changed
+
+* Fix some problems with commanders gem
+
+## v3.0.0
+
+#### Changed
+
+* Refactoring all gem to working with tesseract version 4  or above
+
 ## v2.1.0
 
 #### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rtesseract (3.0.2)
+    rtesseract (3.0.3)
       nokogiri
 
 GEM
@@ -17,7 +17,7 @@ GEM
     docile (1.3.1)
     json (2.1.0)
     mini_portile2 (2.4.0)
-    nokogiri (1.9.1)
+    nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
     rake (10.5.0)
     rspec (3.8.0)

--- a/lib/rtesseract/configuration.rb
+++ b/lib/rtesseract/configuration.rb
@@ -5,6 +5,10 @@ class RTesseract
     def merge(options)
       RTesseract::Configuration.new(to_h.merge(options))
     end
+
+    def command
+      @table[:command]
+    end
   end
 
   class << self

--- a/lib/rtesseract/version.rb
+++ b/lib/rtesseract/version.rb
@@ -1,3 +1,3 @@
 class RTesseract
-  VERSION = '3.0.2'.freeze
+  VERSION = '3.0.3'.freeze
 end


### PR DESCRIPTION
This PR closes the issues #65.
The openstruct uses method_missing to define yours methods them commanders gem write for all objects the method command.