### PR TITLE
Remove nokogiri

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,3 @@
+rubocop:
+  config_file: .rubocop.yml
+  version: 0.80.0

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,20 @@
-Documentation:
-  Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 150
 
 Metrics/BlockLength:
   Max: 50
+
+Metrics/AbcSize:
+  Max: 30
+
+Style/Documentation:
+  Enabled: false
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,51 +1,45 @@
 PATH
   remote: .
   specs:
-    rtesseract (3.0.5)
-      nokogiri
+    rtesseract (3.1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    coveralls (0.7.2)
-      multi_json (~> 1.3)
-      rest-client (= 1.6.7)
-      simplecov (>= 0.7)
-      term-ansicolor (= 1.2.2)
-      thor (= 0.18.1)
+    coveralls (0.8.23)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.16.1)
+      term-ansicolor (~> 1.3)
+      thor (>= 0.19.4, < 2.0)
+      tins (~> 1.6)
     diff-lcs (1.3)
     docile (1.3.2)
-    mime-types (3.3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.1009)
-    mini_portile2 (2.4.0)
-    multi_json (1.14.1)
-    nokogiri (1.10.9)
-      mini_portile2 (~> 2.4.0)
+    json (2.3.0)
     rake (13.0.1)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
       rspec-mocks (~> 3.9.0)
     rspec-core (3.9.1)
       rspec-support (~> 3.9.1)
-    rspec-expectations (3.9.0)
+    rspec-expectations (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
-    simplecov (0.18.5)
+    simplecov (0.16.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11)
-    simplecov-html (0.12.2)
-    term-ansicolor (1.2.2)
-      tins (~> 0.8)
-    thor (0.18.1)
-    tins (0.13.2)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    sync (0.5.0)
+    term-ansicolor (1.7.1)
+      tins (~> 1.0)
+    thor (1.0.1)
+    tins (1.24.1)
+      sync
 
 PLATFORMS
   ruby
@@ -56,7 +50,6 @@ DEPENDENCIES
   rake
   rspec
   rtesseract!
-  simplecov
 
 BUNDLED WITH
    2.1.4

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'rtesseract'

--- a/lib/rtesseract.rb
+++ b/lib/rtesseract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rtesseract/check'
 require 'rtesseract/configuration'
 require 'rtesseract/command'

--- a/lib/rtesseract/base.rb
+++ b/lib/rtesseract/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tmpdir'
 require 'securerandom'
 require 'pathname'

--- a/lib/rtesseract/box.rb
+++ b/lib/rtesseract/box.rb
@@ -1,5 +1,3 @@
-require 'nokogiri'
-
 class RTesseract
   module Box
     extend RTesseract::Base
@@ -13,16 +11,19 @@ class RTesseract
     end
 
     def self.parse(content)
-      html = Nokogiri::HTML(content)
-      html.css('span.ocrx_word, span.ocr_word').map do |word|
-        attributes = word.attributes['title'].value.to_s.delete(';').split(' ')
-        word_info(word, attributes)
-      end
+      content.lines.map do |line|
+        self.word_info(line) if line.match?(/oc(rx|r)_word/)
+      end.compact
     end
 
-    def self.word_info(word, data)
+    def self.word_info(line)
+      data = line.match(/(?<=title)(.*?)(?=;)/).to_s.split(" ")
+      word = line.match(/(?<=>)(.*?)(?=<)/).to_s
+
+      return if word.strip == ''
+
       {
-        word: word.text,
+        word: word,
         x_start: data[1].to_i,
         y_start: data[2].to_i,
         x_end: data[3].to_i,

--- a/lib/rtesseract/box.rb
+++ b/lib/rtesseract/box.rb
@@ -1,39 +1,45 @@
+# frozen_string_literal: true
+
 class RTesseract
   module Box
     extend RTesseract::Base
 
-    def self.run(source, errors, options)
-      options.tessedit_create_hocr = 1
+    class << self
+      def run(source, errors, options)
+        options.tessedit_create_hocr = 1
 
-      RTesseract::Command.new(source, temp_file, errors, options).run
+        RTesseract::Command.new(source, temp_file, errors, options).run
 
-      parse(File.read(temp_file('.hocr')))
-    end
+        parse(File.read(temp_file('.hocr')))
+      end
 
-    def self.parse(content)
-      content.lines.map do |line|
-        next unless line.match?(/oc(rx|r)_word/)
+      def parse(content)
+        content.lines.map { |line| parse_line(line) }.compact
+      end
+
+      def parse_line(line)
+        return unless line.match?(/oc(rx|r)_word/)
 
         word = line.match(/(?<=>)(.*?)(?=<)/).to_s
 
-        next if word.strip == ''
+        return if word.strip == ''
 
         word_info(word, parse_position(line))
-      end.compact
-    end
+      end
 
-    def self.word_info(word, positions)
-      {
-        word: word,
-        x_start: positions[1].to_i,
-        y_start: positions[2].to_i,
-        x_end: positions[3].to_i,
-        y_end: positions[4].to_i
-      }
-    end
+      def word_info(word, positions)
+        {
+          word: word,
+          x_start: positions[1].to_i,
+          y_start: positions[2].to_i,
+          x_end: positions[3].to_i,
+          y_end: positions[4].to_i
+        }
+      end
 
-    def self.parse_position(line)
-      line.match(/(?<=title)(.*?)(?=;)/).to_s.split(' ')
+      def parse_position(line)
+        line.match(/(?<=title)(.*?)(?=;)/).to_s.split(' ')
+      end
     end
   end
 end

--- a/lib/rtesseract/box.rb
+++ b/lib/rtesseract/box.rb
@@ -12,23 +12,28 @@ class RTesseract
 
     def self.parse(content)
       content.lines.map do |line|
-        self.word_info(line) if line.match?(/oc(rx|r)_word/)
+        next unless line.match?(/oc(rx|r)_word/)
+
+        word = line.match(/(?<=>)(.*?)(?=<)/).to_s
+
+        next if word.strip == ''
+
+        word_info(word, parse_position(line))
       end.compact
     end
 
-    def self.word_info(line)
-      data = line.match(/(?<=title)(.*?)(?=;)/).to_s.split(" ")
-      word = line.match(/(?<=>)(.*?)(?=<)/).to_s
-
-      return if word.strip == ''
-
+    def self.word_info(word, positions)
       {
         word: word,
-        x_start: data[1].to_i,
-        y_start: data[2].to_i,
-        x_end: data[3].to_i,
-        y_end: data[4].to_i
+        x_start: positions[1].to_i,
+        y_start: positions[2].to_i,
+        x_end: positions[3].to_i,
+        y_end: positions[4].to_i
       }
+    end
+
+    def self.parse_position(line)
+      line.match(/(?<=title)(.*?)(?=;)/).to_s.split(' ')
     end
   end
 end

--- a/lib/rtesseract/check.rb
+++ b/lib/rtesseract/check.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RTesseract
   class << self
     def tesseract_version

--- a/lib/rtesseract/command.rb
+++ b/lib/rtesseract/command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RTesseract
   class Command
     FIXED = %i[command psm oem lang tessdata_dir user_words user_patterns config_file].freeze

--- a/lib/rtesseract/configuration.rb
+++ b/lib/rtesseract/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ostruct'
 
 class RTesseract

--- a/lib/rtesseract/pdf.rb
+++ b/lib/rtesseract/pdf.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RTesseract
   module Pdf
     extend Base

--- a/lib/rtesseract/text.rb
+++ b/lib/rtesseract/text.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'open3'
 
 class RTesseract

--- a/lib/rtesseract/tsv.rb
+++ b/lib/rtesseract/tsv.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RTesseract
   module Tsv
     extend Base

--- a/lib/rtesseract/version.rb
+++ b/lib/rtesseract/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RTesseract
-  VERSION = '3.1.0'.freeze
+  VERSION = '3.1.0'
 end

--- a/lib/rtesseract/version.rb
+++ b/lib/rtesseract/version.rb
@@ -1,3 +1,3 @@
 class RTesseract
-  VERSION = '3.0.5'.freeze
+  VERSION = '3.1.0'.freeze
 end

--- a/rtesseract.gemspec
+++ b/rtesseract.gemspec
@@ -26,7 +26,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'simplecov'
-
-  spec.add_dependency 'nokogiri'
 end

--- a/rtesseract.gemspec
+++ b/rtesseract.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'rtesseract/version'
@@ -8,9 +10,9 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Danilo Jeremias da Silva']
   spec.email         = ['dannnylo@gmail.com']
 
-  spec.summary       = 'Ruby library for working with the Tesseract OCR.'.freeze
-  spec.description   = 'Ruby library for working with the Tesseract OCR.'.freeze
-  spec.homepage      = 'http://github.com/dannnylo/rtesseract'.freeze
+  spec.summary       = 'Ruby library for working with the Tesseract OCR.'
+  spec.description   = 'Ruby library for working with the Tesseract OCR.'
+  spec.homepage      = 'http://github.com/dannnylo/rtesseract'
   spec.license       = 'MIT'
 
   # Specify which files should be added to the gem when it is released.

--- a/spec/rtesseract/box_spec.rb
+++ b/spec/rtesseract/box_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RTesseract::Box do
   let(:path) { Pathname.new(File.dirname(__FILE__)).join('..') }
   let(:words_image) { path.join('resources', 'test_words.png').to_s }

--- a/spec/rtesseract/configuration_spec.rb
+++ b/spec/rtesseract/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RTesseract do
   let(:path) { Pathname.new(File.dirname(__FILE__)).join('..') }
 

--- a/spec/rtesseract/pdf_spec.rb
+++ b/spec/rtesseract/pdf_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RTesseract::Pdf do
   let(:path) { Pathname.new(File.dirname(__FILE__)).join('..') }
 

--- a/spec/rtesseract/tsv_spec.rb
+++ b/spec/rtesseract/tsv_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'csv'
 
 RSpec.describe RTesseract::Tsv do

--- a/spec/rtesseract_spec.rb
+++ b/spec/rtesseract_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RTesseract do
   let(:path) { Pathname.new(__dir__) }
   let(:image_path) { path.join('resources', 'test.tif').to_s }
@@ -52,7 +54,7 @@ RSpec.describe RTesseract do
   it 'store the error on a variable to debug' do
     instance = RTesseract.new
     expect { instance.to_s }.to raise_error(RTesseract::Error)
-    expect(instance.errors.first).to include("Error during processing")
+    expect(instance.errors.first).to include('Error during processing')
 
     error_intance = RTesseract.new(path.join('resources', 'image_with_error.png').to_s)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 require 'coveralls'
 require 'simplecov'


### PR DESCRIPTION
This PR removes the dependency of gem Nokogiri to parse the HOCR and updates the gems to fix security alerts.

And bump the version to 3.1.0