### PR TITLE
Fix thread safety

### DIFF
--- a/lib/rtesseract.rb
+++ b/lib/rtesseract.rb
@@ -54,7 +54,7 @@ class RTesseract
 
   def new_temp_file_path
     rand_file ||= "rtesseract_#{SecureRandom.uuid}"
-    Pathname.new(Dir.tmpdir).join("#{rand_file}").to_s
+    Pathname.new(Dir.tmpdir).join(rand_file).to_s
   end
 
   attr_reader :errors

--- a/lib/rtesseract.rb
+++ b/lib/rtesseract.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'tmpdir'
+require 'securerandom'
+require 'pathname'
 require 'rtesseract/check'
 require 'rtesseract/configuration'
 require 'rtesseract/command'
@@ -21,7 +24,8 @@ class RTesseract
   end
 
   def to_box
-    Box.run(@source, @errors, config)
+    temp_file_path = new_temp_file_path
+    Box.run(@source, temp_file_path, @errors, config)
   end
 
   def words
@@ -29,11 +33,13 @@ class RTesseract
   end
 
   def to_pdf
-    Pdf.run(@source, @errors, config)
+    temp_file_path = new_temp_file_path
+    Pdf.run(@source, temp_file_path, @errors, config)
   end
 
   def to_tsv
-    Tsv.run(@source, @errors, config)
+    temp_file_path = new_temp_file_path
+    Tsv.run(@source, temp_file_path, @errors, config)
   end
 
   # Output value
@@ -44,6 +50,11 @@ class RTesseract
   # Remove spaces and break-lines
   def to_s_without_spaces
     to_s.gsub(/\s/, '')
+  end
+
+  def new_temp_file_path
+    rand_file ||= "rtesseract_#{SecureRandom.uuid}"
+    Pathname.new(Dir.tmpdir).join("#{rand_file}").to_s
   end
 
   attr_reader :errors

--- a/lib/rtesseract/base.rb
+++ b/lib/rtesseract/base.rb
@@ -1,15 +1,6 @@
 # frozen_string_literal: true
 
-require 'tmpdir'
-require 'securerandom'
-require 'pathname'
-
 class RTesseract
   module Base
-    def temp_file(ext = '')
-      @rand_file ||= "rtesseract_#{SecureRandom.uuid}"
-
-      Pathname.new(Dir.tmpdir).join("#{@rand_file}#{ext}").to_s
-    end
   end
 end

--- a/lib/rtesseract/box.rb
+++ b/lib/rtesseract/box.rb
@@ -5,12 +5,12 @@ class RTesseract
     extend RTesseract::Base
 
     class << self
-      def run(source, errors, options)
+      def run(source, temp_file_path, errors, options)
         options.tessedit_create_hocr = 1
 
-        RTesseract::Command.new(source, temp_file, errors, options).run
+        RTesseract::Command.new(source, temp_file_path, errors, options).run
 
-        parse(File.read(temp_file('.hocr')))
+        parse(File.read("#{temp_file_path}.hocr"))
       end
 
       def parse(content)

--- a/lib/rtesseract/pdf.rb
+++ b/lib/rtesseract/pdf.rb
@@ -4,12 +4,12 @@ class RTesseract
   module Pdf
     extend Base
 
-    def self.run(source, errors, options)
+    def self.run(source, temp_file_path, errors, options)
       options.tessedit_create_pdf = 1
 
-      RTesseract::Command.new(source, temp_file, errors, options).run
+      RTesseract::Command.new(source, temp_file_path, errors, options).run
 
-      File.open(temp_file('.pdf'), 'r')
+      File.open("#{temp_file_path}.pdf", 'r')
     end
   end
 end

--- a/lib/rtesseract/tsv.rb
+++ b/lib/rtesseract/tsv.rb
@@ -4,12 +4,12 @@ class RTesseract
   module Tsv
     extend Base
 
-    def self.run(source, errors, options)
+    def self.run(source, temp_file_path, errors, options)
       options.tessedit_create_tsv = 1
 
-      RTesseract::Command.new(source, temp_file, errors, options).run
+      RTesseract::Command.new(source, temp_file_path, errors, options).run
 
-      File.open(temp_file('.tsv'), 'r')
+      File.open("#{temp_file_path}.tsv", 'r')
     end
   end
 end


### PR DESCRIPTION
Assigning `@rand_file` in `RTesseract::Base` breaks thread safety.

https://github.com/dannnylo/rtesseract/blob/f50e774d119136439c93593f879e2443475caab4/lib/rtesseract/base.rb#L10

This PR fixes that by passing a temp_file along to each format module.

We discovered this while attempting to use `RTesseract` in a `sidekiq` worker. Sidekiq makes heavy use of threads and is great for exposing these things. :smile: 

Thanks for your work on this gem @dannnylo!