### PR TITLE
Include confidence alongside each word in box mode

### DIFF
--- a/lib/rtesseract/box.rb
+++ b/lib/rtesseract/box.rb
@@ -24,21 +24,26 @@ class RTesseract
 
         return if word.strip == ''
 
-        word_info(word, parse_position(line))
+        word_info(word, parse_position(line), parse_confidence(line))
       end
 
-      def word_info(word, positions)
+      def word_info(word, positions, confidence)
         {
           word: word,
           x_start: positions[1].to_i,
           y_start: positions[2].to_i,
           x_end: positions[3].to_i,
-          y_end: positions[4].to_i
+          y_end: positions[4].to_i,
+          confidence: confidence[-1].to_i,
         }
       end
 
       def parse_position(line)
         line.match(/(?<=title)(.*?)(?=;)/).to_s.split(' ')
+      end
+
+      def parse_confidence(line)
+        line.match(/(?<=;)(.*?)(?=')/).to_s.split(' ')
       end
     end
   end


### PR DESCRIPTION
sample:

```
[2] pry(main)> RTesseract.new('/Volumes/Acadia/records.original.images/001-001.png').to_box
=> [{:word=>"THE", :x_start=>643, :y_start=>106, :x_end=>728, :y_end=>135, :confidence=>96},
 {:word=>"DECLARATION", :x_start=>237, :y_start=>214, :x_end=>602, :y_end=>259, :confidence=>95},
 {:word=>"OF", :x_start=>629, :y_start=>215, :x_end=>692, :y_end=>259, :confidence=>96},
 {:word=>"INDEPENDENCE.", :x_start=>718, :y_start=>214, :x_end=>1137, :y_end=>259, :confidence=>96},
 {:word=>"In", :x_start=>447, :y_start=>429, :x_end=>484, :y_end=>457, :confidence=>93},
 {:word=>"Coneress,", :x_start=>505, :y_start=>429, :x_end=>667, :y_end=>462, :confidence=>88},
 {:word=>"Juty", :x_start=>687, :y_start=>427, :x_end=>766, :y_end=>456, :confidence=>64},
 {:word=>"4,", :x_start=>787, :y_start=>428, :x_end=>816, :y_end=>461, :confidence=>96},
 {:word=>"1776.", :x_start=>838, :y_start=>427, :x_end=>918, :y_end=>455, :confidence=>96},
 {:word=>"THE", :x_start=>121, :y_start=>499, :x_end=>207, :y_end=>528, :confidence=>94},
 {:word=>"UNANIMOUS", :x_start=>238, :y_start=>498, :x_end=>481, :y_end=>527, :confidence=>96},
 {:word=>"DECLARATION", :x_start=>513, :y_start=>495, :x_end=>805, :y_end=>525, :confidence=>96},
 {:word=>"OF", :x_start=>832, :y_start=>494, :x_end=>884, :y_end=>523, :confidence=>95},
 {:word=>"THE", :x_start=>910, :y_start=>493, :x_end=>998, :y_end=>522, :confidence=>95},
 {:word=>"THIRTEEN", :x_start=>1023, :y_start=>492, :x_end=>1241, :y_end=>522, :confidence=>96},
 {:word=>"UNITED", :x_start=>368, :y_start=>546, :x_end=>526, :y_end=>575, :confidence=>96},
 {:word=>"STATES", :x_start=>548, :y_start=>545, :x_end=>704, :y_end=>574, :confidence=>96},
 {:word=>"OF", :x_start=>726, :y_start=>544, :x_end=>779, :y_end=>572, :confidence=>96},
 {:word=>"AMERICA.", :x_start=>801, :y_start=>542, :x_end=>996, :y_end=>572, :confidence=>95},
 {:word=>"Wuen,", :x_start=>150, :y_start=>627, :x_end=>262, :y_end=>662, :confidence=>42},
 {:word=>"in", :x_start=>278, :y_start=>627, :x_end=>306, :y_end=>655, :confidence=>96},
 {:word=>"the", :x_start=>326, :y_start=>627, :x_end=>373, :y_end=>654, :confidence=>96},
 {:word=>"course", :x_start=>394, :y_start=>635, :x_end=>494, :y_end=>655, :confidence=>96},
 {:word=>"of", :x_start=>508, :y_start=>625, :x_end=>542, :y_end=>653, :confidence=>96},
 {:word=>"human", :x_start=>557, :y_start=>625, :x_end=>660, :y_end=>653, :confidence=>96},
 {:word=>"events,", :x_start=>676, :y_start=>628, :x_end=>779, :y_end=>657, :confidence=>96},
 {:word=>"it", :x_start=>794, :y_start=>623, :x_end=>814, :y_end=>650, :confidence=>96},
 {:word=>"becomes", :x_start=>827, :y_start=>622, :x_end=>958, :y_end=>650, :confidence=>96},
```