### PR TITLE
Fixing configuration error. See changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changes
+## v3.1.3
+
+* Fixed a configuration error that wouldn't allow you to do different kinds of calls on the same object, for example calling .to_box and then .to_s would result in unexpected behavior.
+
 ## v3.1.2
 
 #### Added

--- a/README.md
+++ b/README.md
@@ -20,9 +20,17 @@ Ruby library for working with the Tesseract OCR.
 
 ## Installation
 
-Check if tesseract ocr programs is installed:
+Check if tesseract ocr programs are installed:
 
     $ tesseract --version
+
+If not, you can install them with a command like:
+
+    $ apt install tesseract-ocr
+
+or
+
+    $ brew install tesseract
 
 Add this line to your application's Gemfile:
 

--- a/lib/rtesseract.rb
+++ b/lib/rtesseract.rb
@@ -21,7 +21,7 @@ class RTesseract
   end
 
   def to_box
-    Box.run(@source, @errors, config)
+    Box.run(@source, @errors, @config)
   end
 
   def words
@@ -29,16 +29,16 @@ class RTesseract
   end
 
   def to_pdf
-    Pdf.run(@source, @errors, config)
+    Pdf.run(@source, @errors, @config)
   end
 
   def to_tsv
-    Tsv.run(@source, @errors, config)
+    Tsv.run(@source, @errors, @config)
   end
 
   # Output value
   def to_s
-    Text.run(@source, @errors, config)
+    Text.run(@source, @errors, @config)
   end
 
   # Remove spaces and break-lines

--- a/lib/rtesseract/box.rb
+++ b/lib/rtesseract/box.rb
@@ -6,7 +6,7 @@ class RTesseract
 
     class << self
       def run(source, errors, options)
-        options.tessedit_create_hocr = 1
+        options = options.merge({tessedit_create_hocr: 1})
 
         RTesseract::Command.new(source, temp_file_path, errors, options).run do |output_path|
           parse(File.read("#{output_path}.hocr"))

--- a/lib/rtesseract/pdf.rb
+++ b/lib/rtesseract/pdf.rb
@@ -5,7 +5,7 @@ class RTesseract
     extend Base
 
     def self.run(source, errors, options)
-      options.tessedit_create_pdf = 1
+      options = options.merge({tessedit_create_pdf: 1})
 
       RTesseract::Command.new(source, temp_file_path, errors, options).run do |output_path|
         File.open("#{output_path}.pdf", 'r')

--- a/lib/rtesseract/tsv.rb
+++ b/lib/rtesseract/tsv.rb
@@ -5,7 +5,7 @@ class RTesseract
     extend Base
 
     def self.run(source, errors, options)
-      options.tessedit_create_tsv = 1
+      options = options.merge({tessedit_create_tsv: 1})
 
       RTesseract::Command.new(
         source,

--- a/lib/rtesseract/version.rb
+++ b/lib/rtesseract/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class RTesseract
-  VERSION = '3.1.2'
+  VERSION = '3.1.3'
 end

--- a/spec/rtesseract/text_spec.rb
+++ b/spec/rtesseract/text_spec.rb
@@ -34,4 +34,15 @@ RSpec.describe RTesseract::Text do
   it 'tests output text' do
     expect(RTesseract.new(words_image).to_s).to eql("If you are a friend,\nyou speak the password,\nand the doors will open.\n\f")
   end
+
+  it 'tests config errors' do
+    tesseract = RTesseract.new(words_image)
+    # Check that none of the other options affects the config, making text error out.
+    box = tesseract.to_box
+    pdf = tesseract.to_pdf
+    tsv = tesseract.to_tsv
+    result = tesseract.to_s
+    expect(result).to eql("If you are a friend,\nyou speak the password,\nand the doors will open.\n\f")
+  end
 end
+


### PR DESCRIPTION
Just try running my new test and you'll see the error.

Calling ".to_box" shouldn't make it impossible to then call ".to_s" later, but the default config of the object is being overwritten, which it should not be.