### PR TITLE
Resolve ruby 3.3.5 warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changes
+## v3.1.4
+
+* Ruby 3.3.5 is removing ostruct as default gem, added as dependency.
+
 ## v3.1.3
 
 * Fixed a configuration error that wouldn't allow you to do different kinds of calls on the same object, for example calling .to_box and then .to_s would result in unexpected behavior.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,14 @@ PATH
   remote: .
   specs:
     rtesseract (3.1.3)
+      ostruct (~> 0.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.4.4)
     docile (1.4.0)
+    ostruct (0.6.0)
     rake (13.0.6)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)

--- a/lib/rtesseract/version.rb
+++ b/lib/rtesseract/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class RTesseract
-  VERSION = '3.1.3'
+  VERSION = '3.1.4'
 end

--- a/rtesseract.gemspec
+++ b/rtesseract.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 
-  spec.add_dependency 'ostruct', '~> 0.6'
+  spec.add_dependency 'ostruct', '~> 0.6' if RUBY_VERSION >= '3.3.5'
 end

--- a/rtesseract.gemspec
+++ b/rtesseract.gemspec
@@ -26,4 +26,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.metadata['rubygems_mfa_required'] = 'true'
+
+  spec.add_dependency 'ostruct', '~> 0.6'
 end


### PR DESCRIPTION
Ruby 3.3.5 is removing ostruct as a default gem:

```
warning: ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of rtesseract-3.1.3 to request adding ostruct into its gemspec.
```

Added gemspec dependency to resolve.